### PR TITLE
handle string nan results in pool_health_check_stats

### DIFF
--- a/pgpool2_exporter.go
+++ b/pgpool2_exporter.go
@@ -447,12 +447,18 @@ func dbToFloat64(t interface{}) (float64, bool) {
 	case []byte:
 		// Try and convert to string and then parse to a float64
 		strV := string(v)
+		if strV == "-nan" || strV == "nan" {
+			return math.NaN(), true
+		}
 		result, err := strconv.ParseFloat(strV, 64)
 		if err != nil {
 			return math.NaN(), false
 		}
 		return result, true
 	case string:
+		if v == "-nan" || v == "nan" {
+			return math.NaN(), true
+		}
 		result, err := strconv.ParseFloat(v, 64)
 		if err != nil {
 			level.Error(logger).Log("msg", "Could not parse string", "err", err)


### PR DESCRIPTION
If a node is defined but in status=unused, the `average_retry_count`
and `average_duration` columns appear to return a literal string
result of `-nan`.  The result parsing switch correctly returns
`math.NaN()` in this case, but will return `false` as the second return
value, leading to errors being logged:

```
ts=2022-01-24T15:09:10.003Z caller=log.go:168 level=info msg="error parsing" err="Unexpected error parsing column:  pool_health_check_stats average_retry_count [45 110 97 110]\n"
ts=2022-01-24T15:09:10.003Z caller=log.go:168 level=info msg="error parsing" err="Unexpected error parsing column:  pool_health_check_stats average_duration [45 110 97 110]\n"
```

(45, 110, 97, 110 are the sequential ordinal values for `-nan`)

Check for a literal value of `-nan` in the string/byte parsing portion
of `dbToFloat64()` and return `math.NaN(), true`, since in this case
we are correctly forwarding a NaN value.