### PR TITLE
Adds pool_nodes.pg_status metric

### DIFF
--- a/pgpool2_exporter.go
+++ b/pgpool2_exporter.go
@@ -165,7 +165,8 @@ var (
 			"hostname":          {LABEL, "Backend hostname"},
 			"port":              {LABEL, "Backend port"},
 			"role":              {LABEL, "Role (primary or standby)"},
-			"status":            {GAUGE, "Backend node Status (1 for up or waiting, 0 for down or unused)"},
+			"status":            {GAUGE, "Pool node status (1 for up or waiting, 0 for down or unused)"},
+			"pg_status":         {GAUGE, "Backend pg status (1 for up or waiting, 0 for down or unused)"},
 			"select_cnt":        {COUNTER, "SELECT statement counts issued to each backend"},
 			"replication_delay": {GAUGE, "Replication delay"},
 		},
@@ -497,7 +498,7 @@ func queryNamespaceMapping(ch chan<- prometheus.Metric, db *sql.DB, namespace st
 				}
 
 				// If status column, convert string to int.
-				if columnName == "status" {
+				if columnName == "status" || columnName == "pg_status" {
 					valueString, ok := dbToString(columnData[idx])
 					if !ok {
 						nonfatalErrors = append(nonfatalErrors, errors.New(fmt.Sprintln("Unexpected error parsing column: ", namespace, columnName, columnData[idx])))


### PR DESCRIPTION
Adds a new guage for `pg_status` column in `SHOW POOL_NODES;` output.

```
# HELP pgpool2_pool_nodes_pg_status Backend pg status (1 for up or waiting, 0 for down or unused)
# TYPE pgpool2_pool_nodes_pg_status gauge
pgpool2_pool_nodes_pg_status{hostname="primary01.example.com",port="4432",role="primary"} 1
pgpool2_pool_nodes_pg_status{hostname="standby01.example.com",port="4432",role="standby"} 1
pgpool2_pool_nodes_pg_status{hostname="standby01.example.com",port="4432",role="standby"} 1
```

This is helpful for when you want to visualize frontend (pgpool) vs backend (postgres) status.