### PR TITLE
Make error on Debian 11 with Go

### DIFF
--- a/pgpool2_exporter.go
+++ b/pgpool2_exporter.go
@@ -28,7 +28,7 @@ import (
 	"fmt"
 	"math"
 	"net/url"
-	"os"
+	_ "os"
 	"regexp"
 	"strconv"
 	"sync"


### PR DESCRIPTION
### Fixes #30 issue
---
Fixes error occuring when making project from master branch:

```
[gopher@HYPERION pgpool2_exporter]$ make
>> building binaries
 >   pgpool2_exporter
# github.com/pgpool/pgpool2_exporter
./pgpool2_exporter.go:31:2: "os" imported and not used
!! command failed: build -o /home/gopher/pgpool2_exporter/pgpool2_exporter -ldflags -X github.com/prometheus/common/version.Version=1.2.1 -X github.com/prometheus/common/version.Revision=c76acd4012c52869f11c3fffd7ab626e2d0144b5 -X github.com/prometheus/common/version.Branch=master -X github.com/prometheus/common/version.BuildUser=gopher@HYPERION -X github.com/prometheus/common/version.BuildDate=20240111-15:05:24  -extldflags '-static' -a -tags 'netgo static_build' github.com/pgpool/pgpool2_exporter/cmd/pgpool2_exporter: exit status 1
make: *** [Makefile:17: build] Error 1
```
